### PR TITLE
(build) Make sure it runs: webdriver-manager update before running protr...

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ npm install -g benchpress
 
 Run ngTasty benchmark
 ```
-protractor benchmarks/protractor.conf.js --specs benchmarks/dist/benchmark.spec.js
+npm run protractor
 ```
 
 Open benchmark with Chrome

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test": "gulp test",
     "watch": "gulp watch",
     "preprotractor": "webdriver-manager update",
-    "protractor": "protractor benchmarks/protractor.conf.js"
+    "protractor": "protractor benchmarks/protractor.conf.js --specs benchmarks/dist/benchmark.spec.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "start": "node docs/server.js port=3000",
     "start_docs": "node docs/server.js port=25907",
     "test": "gulp test",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+    "preprotractor": "webdriver-manager update",
+    "protractor": "protractor benchmarks/protractor.conf.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
...actor. It is necessary to do this in order to run the tests for the first ime.

Updated docs: Simpler command to run protractor: npm run protractor