### PR TITLE
cleanFieldName may now contain _ and keep it, instead of replacing it

### DIFF
--- a/src/filter/clean-field-name.js
+++ b/src/filter/clean-field-name.js
@@ -14,6 +14,6 @@
 angular.module('ngTasty.filter.cleanFieldName', [])
 .filter('cleanFieldName', function() {
   return function (input) {
-    return input.replace(/[^a-zA-Z0-9-]+/g, '-');
+    return input.replace(/[^a-zA-Z0-9-_-]+/g, '-');
   };
 });

--- a/src/filter/test/clean-field-name.spec.js
+++ b/src/filter/test/clean-field-name.spec.js
@@ -14,5 +14,8 @@ describe('Filter: cleanFieldName', function () {
   it('should return ...', function () {
     expect(cleanFieldName('SF Location')).toEqual('SF-Location');
   });
-
+  
+  it('should return ...', function () {
+    expect(cleanFieldName('SF_Location')).toEqual('SF_Location');
+  });
 });


### PR DESCRIPTION
Hi, 
I've started using this great component for my project and came across an odd issue. 

What happened was that I've gotten the key value as 'some_value' from the server for the header. And after I've tried to click on the header to sort it, nothing happened and no errors occurred.
Well the first time something does happen, but the icon does not get set properly and on second click you can't click it anymore. 

I think I've managed to fix the problem.

Also added a test-case to see if it was working. 

If you want to see what was wrong on the regular branch you can add the following lines to the `server.js`
```javascript
(line 112)
rows = [
    { 'name': 'Ritual Coffee Roasters', 'star': '★★★★★', 'sf-location': 'Hayes Valley', 'some_value': 'Test'},
    { 'name': 'Blue Bottle', 'star': '★★★★★', 'sf-location': 'Hayes Valley', 'some_value': 'Test'},
    { 'name': 'CoffeeShop', 'star': '★★★', 'sf-location': 'Bernal Heights', 'some_value': 'Test'},
    { 'name': 'Spike\'s Coffee & Teas', 'star': '★★★', 'sf-location': 'Castro', 'some_value': 'Test'},
    { 'name': 'La Boulange', 'star': '★★', 'sf-location': 'Cole Valley', 'some_value': 'Test'},
    { 'name': 'Dynamo Donut and Coffee', 'star': '★★★★★', 'sf-location': 'Cow Hollow', 'some_value': 'Test'},
    { 'name': 'The Mill', 'star': '★★★★', 'sf-location': 'Divisadero', 'some_value': 'Test'},
    { 'name': 'Piccino Coffee Bar', 'star': '★★★', 'sf-location': 'Dogpatch', 'some_value': 'Test'},
    { 'name': 'Philz', 'star': '★★★', 'sf-location': 'Downtown', 'some_value': 'Test'},
    { 'name': 'Duboce Park Cafe', 'star': '★★', 'sf-location': 'Duboce Triangle', 'some_value': 'Test'},
    { 'name': 'Blue Bottle', 'star': '★★★★★', 'sf-location': 'Embarcadero', 'some_value': 'Test'},
    { 'name': 'Four Barrel', 'star': '★★★', 'sf-location': 'Excelsior', 'some_value': 'Test'},
    { 'name': 'Coffee Bar', 'star': '★★★★★', 'sf-location': 'FiDi', 'some_value': 'Test'},
    { 'name': 'Biscoff Coffee Corner', 'star': '★★★', 'sf-location': 'Fisherman’s Wharf', 'some_value': 'Test'},
    { 'name': 'Fifty/Fifty Coffee and Tea', 'star': '★★★', 'sf-location': 'Inner Richmond', 'some_value': 'Test'},
    { 'name': 'Beanery', 'star': '★★★', 'sf-location': 'Inner Sunset', 'some_value': 'Test'},
    { 'name': 'Cafe du Soleil', 'star': '★★', 'sf-location': 'Lower Haight', 'some_value': 'Test'},
    { 'name': 'Dimmi Tutto Cafe', 'star': '★★★', 'sf-location': 'North Beach', 'some_value': 'Test'},
    { 'name': 'Peet\'s', 'star': '★', 'sf-location': 'The Marina', 'some_value': 'Test'},
    { 'name': 'Sightglass', 'star': '★★★★', 'sf-location': 'The Mission', 'some_value': 'Test'},
    { 'name': 'Contraband Coffee Bar', 'star': '★★★★', 'sf-location': 'Nob Hill', 'some_value': 'Test'},
    { 'name': 'Martha & Bros Coffee', 'star': '★★★', 'sf-location': 'Noe Valley', 'some_value': 'Test'},
    { 'name': 'Réveille', 'star': '★★★', 'sf-location': 'North Beach', 'some_value': 'Test'},
    { 'name': 'Cup Coffee Bar', 'star': '★★★', 'sf-location': 'Outer Mission', 'some_value': 'Test'},
    { 'name': 'Garden House Cafe', 'star': '★★★', 'sf-location': 'Outer Richmond', 'some_value': 'Test'},
    { 'name': 'Andytown Coffee Roasters', 'star': '★★★', 'sf-location': 'Outer Sunset', 'some_value': 'Test'},
    { 'name': 'Jane on Fillmore', 'star': '★★', 'sf-location': 'Pacific Heights', 'some_value': 'Test'},
    { 'name': 'Saint Frank Coffee', 'star': '★★★', 'sf-location': 'Polk', 'some_value': 'Test'},
    { 'name': 'Farley’s', 'star': '★★★', 'sf-location': 'Potrero Hill', 'some_value': 'Test'},
    { 'name': 'House of Snacks', 'star': '★★★', 'sf-location': 'The Presidio', 'some_value': 'Test'},
    { 'name': 'The Brew', 'star': '★★★', 'sf-location': 'Russian Hill' , 'some_value': 'Test'},
    { 'name': 'Wicked Grounds', 'star': '★★★', 'sf-location': 'SOMA', 'some_value': 'Test'},
    { 'name': 'Starbucks', 'star': '★', 'sf-location': 'Union Square', 'some_value': 'Test'},
    { 'name': 'Flywheel Coffee Roasters', 'star': '★★★★★', 'sf-location': 'Upper Haight', 'some_value': 'Welp'},
  ];

// from line 182 so the server sorts the table when we want it to.
} else if (req.query['some_value'] && req.query['some_value'].length) {
      location = req.query['some_value'].toLowerCase();
      return el['some_vlaue'].toLowerCase().indexOf(location) >= 0;

// from line 217 an extra header key value for the table to display.
{
        'key': 'some_value', 
        'name': 'Test Column'
}
```

And the following line to the `complete.html` in `docs/template/table-server-side/`
```html
from line 26
<tr ng-repeat="row in rows">
              <td>{{ row.name }}</td>
              <td>{{ row.star }}</td>
              <td>{{ row['sf-location'] }}</td>
              <td>{{ row.some_value }}</td> <!-- this one -->
</tr>
```
And if you go to the table server side on the docs page and then the complete section, you should be able to see what I mean. 

My best regards and hope this was clear enough.

ps. Keep up the great work!

