### PR TITLE
adding loadOnInit setting to tableConfig

### DIFF
--- a/src/component/table.js
+++ b/src/component/table.js
@@ -29,6 +29,7 @@ angular.module('ngTasty.component.table', [
     'sortOrder': 'sort-order'
   },
   bindOnce: true,
+  loadOnInit: false,
   iconUp: 'fa fa-sort-up',
   iconDown: 'fa fa-sort-down',
   bootstrapIcon: false,
@@ -41,7 +42,7 @@ angular.module('ngTasty.component.table', [
 .controller('TableController', function($scope, $attrs, $filter, tableConfig, tastyUtil) {
   var listScopeToWatch, initTable, newScopeName, initStatus,
       updateClientSideResource, updateServerSideResource, setDirectivesValues,
-      buildClientResource, buildUrl, paramsInitialCycle, initNow;
+      buildClientResource, buildUrl, paramsInitialCycle, initNow, loadOnInit;
   this.$scope = $scope;
   initStatus = {};
   initNow = true;
@@ -94,7 +95,8 @@ angular.module('ngTasty.component.table', [
   $scope.query.sortOrder = $scope.query.sortOrder || this.config.query.sortOrder;
 
   // Set init configs
-  if ($scope.reload) {
+  loadOnInit = $attrs.hasOwnProperty('loadOnInit') || this.config.loadOnInit;
+  if ($scope.reload && !loadOnInit) {
     initNow = false;
   }
   $scope.init.count = $scope.init.count || this.config.init.count;

--- a/src/component/test/table-server-side.spec.js
+++ b/src/component/test/table-server-side.spec.js
@@ -760,6 +760,62 @@ describe('Component: table server side', function () {
     });
   });
 
+  describe('complete with load-on-init', function () {
+    beforeEach(inject(function ($rootScope, $compile, $http, _$httpBackend_, _completeJSON_) {
+      $scope = $rootScope.$new();
+      $httpBackend = _$httpBackend_;
+      completeJSON = _completeJSON_;
+      $scope.getResource = function (paramsUrl, paramsObj) {
+        return $http.get('api.json?' + paramsUrl).then(function (response) {
+          $scope.paramsUrl = paramsUrl;
+          $scope.paramsObj = paramsObj;
+          return {
+            'rows': response.data.rows,
+            'header': response.data.header,
+            'pagination': response.data.pagination,
+            'sortBy': response.data['sort-by'],
+            'sortOrder': response.data['sort-order']
+          };
+        });
+      };
+      $scope.init = {
+        'count': 20,
+        'page': 4,
+        'sortBy': 'name',
+        'sortOrder': 'dsc'
+      };
+      $scope.filterBy = {
+        'name': '',
+        'sf-location': ''
+      };
+      $scope.reloadCallback = function () {};
+      element = angular.element(''+
+      '<div tasty-table bind-resource-callback="getResource" bind-init="init"'+
+      ' load-on-init bind-filters="filterBy"'+
+      ' bind-reload="reloadCallback">'+
+      '  <table>'+
+      '    <thead tasty-thead></thead>'+
+      '    <tbody>'+
+      '    </tbody>'+
+      '  </table>'+
+      '  <div tasty-pagination></div>'+
+      '</div>');
+      $compile(element)($scope);
+    }));
+
+    afterEach(function() {
+      $httpBackend.verifyNoOutstandingExpectation();
+      $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('should calls getResource after digest', function () {
+      urlToCall = 'api.json?sort-by=name&sort-order=dsc&page=4&count=20';
+      $httpBackend.expectGET(urlToCall).respond(completeJSON);
+      $httpBackend.flush();
+      $scope.$digest();
+    });
+  });
+
 
   describe('complete with bind-reload', function () {
     beforeEach(inject(function ($rootScope, $compile, $http, _$httpBackend_, _completeJSON_) {


### PR DESCRIPTION
I have a situation where I'm providing a reload callback, but I still need the table to load data when initializing, without any filter update or user action. Then I'm adding a tableConfig key called loadOnInit.
Let me know what do you think.