### PR TITLE
sortable can be defined where the columns are defined

### DIFF
--- a/src/component/table.js
+++ b/src/component/table.js
@@ -556,11 +556,16 @@ angular.module('ngTasty.component.table', [
           isSortedCaret = '';
           // Not sort column when the key is present in the `notSortBy` list,
           // and Not sort column when `notSortBy` is an empty list
+          // If sortable property is present in column object, then use it
           if (angular.isArray(scope.notSortBy)) {
             if (scope.notSortBy.length) {
               sortable = scope.notSortBy.indexOf(column.key) < 0;
             } else {
               sortable = false;
+            }
+          } else {
+            if (angular.isDefined(column.sortable)) {
+              sortable = column.sortable === true;
             }
           }
           if (column.key === scope.header.sortBy ||


### PR DESCRIPTION
It would be nice if one can configure all properties of a column in the header array in the data object.
```
{
  "header": [
    {
      "key": "name",
      "name": "Name",
      "sortable": false
    },
    ...
  ],
  "rows": [
        ...
  ]
}

```