### PR TITLE
TastyPagination should use the bind-items-per-page attribute value if it exists

### DIFF
--- a/src/component/table.js
+++ b/src/component/table.js
@@ -732,7 +732,7 @@ angular.module('ngTasty.component.table', [
 
       // Serve side table case
       if (!tastyTable.$scope.clientSide) {
-        scope.itemsPerPage = tastyTable.$scope.init.count || scope.itemsPerPage;
+        scope.itemsPerPage = scope.itemsPerPage || tastyTable.$scope.init.count;
       }
 
       // Internal variable


### PR DESCRIPTION
A small bug makes `tastyPagination` always use default config `init.count` as `items-per-page` config. `tastyPagination` should use the `bind-items-per-page` attribute value if it exists